### PR TITLE
Added support for lower case letters for Code39

### DIFF
--- a/Image/Barcode2/Driver/Code39.php
+++ b/Image/Barcode2/Driver/Code39.php
@@ -145,7 +145,7 @@ class Image_Barcode2_Driver_Code39 extends Image_Barcode2_Common implements Imag
 			$prefix = '';
 			if($character > 'a' && $character < 'z'){
 				$prefix+=$this->_codingmap['+'].'0';
-				$character = mb_strtoupper($character);
+				$character = strtoupper($character);
 			}
             $barcode .= $this->_dumpCode($prefix.$this->_codingmap[$character] . '0');
         }


### PR DESCRIPTION
According to Wikipedia (http://en.wikipedia.org/wiki/Code_39), each lower case character has to be prefixed with +. This exactly what I've done.
